### PR TITLE
Update nhsr.css

### DIFF
--- a/inst/rmarkdown/templates/nhsr-presentation/skeleton/css/nhsr.css
+++ b/inst/rmarkdown/templates/nhsr-presentation/skeleton/css/nhsr.css
@@ -27,6 +27,10 @@ a:hover {
   color:              #005EB8;
 }
 
+li{
+   line-height:        1.5em;
+}
+
 /*-- PARAGRAPH TEXT --*/
 .remark-slide-content {
   font-size:          20px;


### PR DESCRIPTION
Added an li tag to increase the line spacing for bullet points.  Currently they are too close as they seem to inherit a 1 em, which makes them overlap / hard to read.

Thank you for your contribution to the nhsrtheme repo. 
Before submitting this PR, please make sure:

- [x] Your code passes [R CMD check](http://r-pkgs.had.co.nz/check.html)
- [x] Your changes are inline with the [NHS Identity](https://www.england.nhs.uk/nhsidentity/)
- [x] You have added [unit tests](http://r-pkgs.had.co.nz/tests.html)
